### PR TITLE
Add Vercel's Analytics component

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.2.0",
+    "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "next": "15.4.3",
     "react": "19.1.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { Analytics } from '@vercel/analytics/next';
+import { Analytics } from "@vercel/analytics/next";
 
 export const metadata: Metadata = {
   title: "Samuel Tregea",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { Analytics } from '@vercel/analytics/next';
 
 export const metadata: Metadata = {
   title: "Samuel Tregea",
@@ -16,6 +17,7 @@ export default function RootLayout({ children,}: Readonly<{ children: React.Reac
       <body>
         {children}
         <SpeedInsights />
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
Add Vercel's `Analytics` component to allow for web analytics based on [Vercel's documentation](https://vercel.com/docs/analytics/quickstart#add-the-analytics-component-to-your-app).