### PR TITLE
Add Copyright To Website

### DIFF
--- a/__tests__/app/page.test.tsx
+++ b/__tests__/app/page.test.tsx
@@ -12,4 +12,6 @@ test('Renders the Home component', () => {
     expect(screen.getByTestId("whoami")).toBeDefined();
     expect(screen.getByTestId("aboutMe")).toBeDefined();
     expect(screen.getByTestId("experience")).toBeDefined();
+    expect(screen.getByTestId("projects")).toBeDefined();
+    expect(screen.getByTestId("copyright")).toBeDefined();
 });

--- a/__tests__/components/Copyright/Copyright.test.tsx
+++ b/__tests__/components/Copyright/Copyright.test.tsx
@@ -1,0 +1,26 @@
+import {describe, test, expect} from "vitest";
+import {render, screen} from "@testing-library/react";
+import Copyright from "@/components/Copyright/Copyright";
+
+/**
+ * Test suite for the Copyright component.
+ *
+ * This suite tests the rendering of the Copyright component to ensure it
+ * displays the correct information.
+ */
+describe("Copyright", () => {
+
+    /**
+     * Test the rendering of the Copyright component.
+     */
+    test("renders the Copyright component", () => {
+        const currentYear = new Date().getFullYear();
+        const expectedText = `© ${currentYear} Samuel Tregea. All rights reserved.`;
+
+        render(<Copyright/>);
+
+        expect(screen.getByTestId("copyright")).toBeDefined();
+        expect(screen.getByTestId("copyright-text")).toBeDefined();
+        expect(screen.getByTestId("copyright-text").innerHTML).toContain(expectedText);
+    });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import About from "@/components/About/About";
 import Experience from "@/components/Experience/Experience";
 import Projects from "@/components/Projects/Projects";
 import Navbar from "@/components/Navbar/Navbar";
+import Copyright from "@/components/Copyright/Copyright";
 
 /**
  * Home component serves as the main entry point for the application.
@@ -23,6 +24,7 @@ export default function Home() {
                     <Projects/>
                 </div>
                 {/* todo: copyright */}
+                <Copyright />
             </main>
         </div>
     );

--- a/src/components/Copyright/Copyright.module.css
+++ b/src/components/Copyright/Copyright.module.css
@@ -1,0 +1,3 @@
+.copyright {
+    text-align: center;
+}

--- a/src/components/Copyright/Copyright.tsx
+++ b/src/components/Copyright/Copyright.tsx
@@ -1,0 +1,20 @@
+import styles from "./Copyright.module.css";
+import Section from "@/components/utils/Section/Section";
+
+/**
+ * Component that displays general copyright information.
+ *
+ * @component
+ * @example
+ * <Copyright />
+ */
+export default function Copyright() {
+    const currentYear = new Date().getFullYear();
+    const text = `© ${currentYear} Samuel Tregea. All rights reserved.`;
+
+    return (
+        <Section id={"copyright"} data-testid={"copyright"}>
+            <p className={styles.copyright} data-testid={"copyright-text"}>{text}</p>
+        </Section>
+    );
+};

--- a/src/components/MobileMenu/MobileMenu.tsx
+++ b/src/components/MobileMenu/MobileMenu.tsx
@@ -52,13 +52,13 @@ export default function MobileMenu({sections, scrollIntoView, navbarVisible}: Me
     }, [navbarVisible]);
 
     return (
-        <Box sx={{flexGrow: 0, display: {xs: "flex", md: "none" }}} data-testid={"mobileMenu"}>
+        <Box sx={{flexGrow: 0, display: {xs: "flex", md: "none"}}} data-testid={"mobileMenu"}>
             <MenuIcon controls={"menu-appbar"} onClick={openMenu}/>
             <Menu
                 id="menu-appbar"
                 anchorEl={anchorElement}
                 anchorOrigin={{
-                    vertical: "bottom",
+                    vertical: "top",
                     horizontal: "left",
                 }}
                 keepMounted


### PR DESCRIPTION
This pull request introduces a new `Copyright` component to the application, ensuring copyright information is displayed on the home page. It also adds a corresponding test suite for the new component and makes a minor UI adjustment to the mobile menu. The most important changes are grouped below:

**New Copyright Component Integration**

* Added the `Copyright` component to the home page by importing it in `src/app/page.tsx` and rendering it at the bottom of the main content. 
* Implemented the `Copyright` component in `src/components/Copyright/Copyright.tsx`, which displays the current year and copyright information in a styled paragraph.
* Added CSS styling for the copyright text in `src/components/Copyright/Copyright.module.css` to center the text.

**Testing**

* Created a new test suite in `__tests__/components/Copyright/Copyright.test.tsx` to verify the rendering and content of the `Copyright` component.
* Updated the home page test in `__tests__/app/page.test.tsx` to check for the presence of the new `projects` and `copyright` sections.

**UI Adjustment**

* Changed the anchor origin of the mobile menu in `src/components/MobileMenu/MobileMenu.tsx` from "bottom" to "top" for improved positioning.